### PR TITLE
Add missing command to the install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ gem 'commonwealth-vlr-engine', :git => 'https://github.com/boston-library/common
 ```
 Then run the install:
 ```
+$ bundle install
 $ rails generate blacklight:install
 $ rails generate commonwealth_vlr_engine:install
 $ rake db:migrate


### PR DESCRIPTION
After creating a new Rails app and adding `blacklight` and `commonwealth-vlr-engine` to the `Gemfile` you need to run `bundle install` before running `rails generate blacklight:install`
